### PR TITLE
Re-add an AudioListener to the main camera

### DIFF
--- a/VREnhancements/AudioFix.cs
+++ b/VREnhancements/AudioFix.cs
@@ -17,6 +17,7 @@ namespace VREnhancements
                     Object.Destroy(__instance.gameObject.GetComponent<AudioListener>());
                     Object.Destroy(__instance.gameObject.GetComponent<StudioListener>());
                     //add new listener to the main camera that does rotate with the VR headset
+                    SNCameraRoot.main.mainCam.gameObject.AddComponent<AudioListener>();
                     SNCameraRoot.main.mainCam.gameObject.AddComponent<StudioListener>();
                 }
             }


### PR DESCRIPTION
The decision to remove the AudioListener from the main camera creates many issues and as far as I know, has no benefit. Any AudioSources now play at full volume in both channels regardless of the Player's location, leading to issues with obnoxious noises such as [this](https://youtu.be/Ec_zt3qDPhM?t=34) and [this](https://youtu.be/nbqHoLBKK4w?t=392). These issues occur with almost all mod audio (In most cases, adding mod audio via FMOD is an unnecessary hassle so we use the Unity sound system). Many content creators are now playing mods that add audio such as Return of the Ancients in VR, while using this mod because otherwise VR is nearly unplayable, so I believe this should be fixed sooner rather than later.